### PR TITLE
Add time to default filename in save dialog

### DIFF
--- a/src/applib/storage_device.cpp
+++ b/src/applib/storage_device.cpp
@@ -765,7 +765,7 @@ std::string StorageDevice::get_save_filename() const
 {
 	std::string model = this->get_model_name();  // may be empty
 	std::string serial = this->get_serial_number();
-	std::string date = hz::format_date("%Y-%m-%d", true);
+	std::string date = hz::format_date("%Y-%m-%d_%H%M", true);
 
 	auto filename_format = rconfig::get_data<std::string>("gui/smartctl_output_filename_format");
 	hz::string_replace(filename_format, "{serial}", serial);


### PR DESCRIPTION
Adding time (hours+minutes) to already preset date (yyyy-mm-dd) in default filename save dialog.
This should be useful when you need to save multiple files during same day.