### PR TITLE
Fix barely readable info cell texts

### DIFF
--- a/src/gsc_info_window.cpp
+++ b/src/gsc_info_window.cpp
@@ -133,7 +133,7 @@ namespace {
 			if (p->is_value_type<AtaStorageStatistic>() && p->get_value<AtaStorageStatistic>().is_header) {
 				crt->property_weight() = Pango::WEIGHT_BOLD;
 			} else {
-				crt->property_weight().reset_value();
+				crt->property_weight() = Pango::WEIGHT_NORMAL;
 			}
 		}
 	}


### PR DESCRIPTION
By simply resetting values, the rendered cell text colors are barely
readable. Setting Pango::WEIGHT_NORMAL instead of resetting seems to fix this
nicely without any negative consequences.

Signed-off-by: Harald Judt <h.judt@gmx.at>