### PR TITLE
Set LC_ALL to control the locale

### DIFF
--- a/src/applib/async_command_executor.cpp
+++ b/src/applib/async_command_executor.cpp
@@ -159,8 +159,7 @@ bool AsyncCommandExecutor::execute()
 
 	std::unique_ptr<gchar*, decltype(&g_strfreev)> child_env(g_get_environ(), &g_strfreev);
 	if (change_lang) {
-		child_env.reset(g_environ_setenv(child_env.release(), "LANG", "C", TRUE));
-		child_env.reset(g_environ_setenv(child_env.release(), "LC_NUMERIC", "C", TRUE));
+		child_env.reset(g_environ_setenv(child_env.release(), "LC_ALL", "C", TRUE));
 	}
 	std::vector<std::string> envp = Glib::ArrayHandler<std::string>::array_to_vector(child_env.release(),
 			Glib::OWNERSHIP_DEEP);


### PR DESCRIPTION
LANG specifies the default locale, LC_NUMERIC specifies the locale for
that particular category, but LC_ALL overrides all the locale
settings. Thus any user with LC_ALL set can still run into
locale-related problems.

Setting LC_ALL to C avoids any such issue.

See locale(7) for details.

Signed-off-by: Stephen Kitt <steve@sk2.org>