### PR TITLE
hz/intrusive_ptr.h: strncpy() string terminators

### DIFF
--- a/src/hz/intrusive_ptr.h
+++ b/src/hz/intrusive_ptr.h
@@ -100,8 +100,8 @@ struct intrusive_ptr_error : virtual public std::exception {  // from <exception
 		std::size_t tmsg_len = std::strlen(tmsg);
 		std::size_t tname_len = std::strlen(tname);
 		msg_ = new char[msg_len + tmsg_len + tname_len + 1];
-		std::strncpy(msg_, msg, msg_len);
-		std::strncpy(msg_ + msg_len, tmsg, tmsg_len);
+		std::strncpy(msg_, msg, msg_len + 1);
+		std::strncpy(msg_ + msg_len, tmsg, tmsg_len + 1);
 		std::strncpy(msg_ + msg_len + tmsg_len, tname, tname_len + 1);
 	}
 #endif


### PR DESCRIPTION
(I realize this is old code that's all been abandoned in the main branch, but since the 1.1 series branch is still what's being released and packaged by distros... Plus, it's an easy fix.)

When building the error message, ensure each `strncpy()` includes the null byte terminating the copied string, even though the first two will be immediately overwritten by the next part.

Silences this repeated compiler warning:
```text
In file included from /usr/include/string.h:519,
                 from /usr/include/glib-2.0/glib/gslice.h:26,
                 from /usr/include/glib-2.0/glib.h:79,
                 from /usr/include/glibmm-2.4/glibmm/thread.h:39,
                 from /usr/include/glibmm-2.4/glibmm.h:103,
                 from /usr/include/gtkmm-3.0/gtkmm.h:100,
                 from gsc_main_window.cpp:12:
In function 'strncpy',
    inlined from 'hz::intrusive_ptr_error::intrusive_ptr_error(char const*, std::type_info const&)' at ./hz/intrusive_ptr.h:104:15:
/usr/include/bits/string_fortified.h:95:34: warning: 'strncpy' output truncated before terminating nul copying 7 bytes from a string of the same length [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'strncpy',
    inlined from 'hz::intrusive_ptr_error::intrusive_ptr_error(char const*, std::type_info const&)' at ./hz/intrusive_ptr.h:103:15:
/usr/include/bits/string_fortified.h:95:34: warning: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   96 |                                   __glibc_objsize (__dest));
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ./rmn/resource_base.h:36,
                 from ./rmn/resource_node.h:41,
                 from rconfig/rcmain.h:28,
                 from rconfig/rconfig_mini.h:25,
                 from gsc_main_window.cpp:20:
./hz/intrusive_ptr.h: In member function 'hz::intrusive_ptr_error::intrusive_ptr_error(char const*, std::type_info const&)':
./hz/intrusive_ptr.h:99:50: note: length computed here
   99 |                 std::size_t msg_len = std::strlen(msg);
      |                                       ~~~~~~~~~~~^~~~~
```