### PR TITLE
FindFilesystem: Eliminate Win32 warning

### DIFF
--- a/data/cmake/FindFilesystem.cmake
+++ b/data/cmake/FindFilesystem.cmake
@@ -197,12 +197,12 @@ set(_found FALSE)
 if(CXX_FILESYSTEM_HAVE_FS)
     # We have some filesystem library available. Do link checks
     string(CONFIGURE [[
-        #include <cstdlib>
+        #include <iostream>
         #include <@CXX_FILESYSTEM_HEADER@>
 
         int main() {
             auto cwd = @CXX_FILESYSTEM_NAMESPACE@::current_path();
-            printf("%s", cwd.c_str());
+            std::cout << cwd << std::endl;
             return EXIT_SUCCESS;
         }
     ]] code @ONLY)


### PR DESCRIPTION
Using `printf("%s")` with a `std::filesystem::path` on Win32 will cause a compile warning, because `std::filesystem::path::value_type` is technically `wchar_t`.

The warning is harmless, but by using iostream to print the value on `std::cout` instead, the code compiles without warnings.

(The warning can be seen in `<builddir>/CMakeFiles/CMakeOutput.log`, for example):

```text
Run Build Command(s):C:/msys64/usr/bin/make.exe -f Makefile cmTC_9a985/fast && 
/usr/bin/make  -f CMakeFiles/cmTC_9a985.dir/build.make 
CMakeFiles/cmTC_9a985.dir/build
make[1]: Entering directory '.../_build/CMakeFiles/CMakeScratch/TryCompile-dqog5x'
Building CXX object CMakeFiles/cmTC_9a985.dir/src.cxx.obj
/C/msys64/clang64/bin/c++.exe -DCXX_FILESYSTEM_NO_LINK_NEEDED  -std=gnu++17 -MD 
-MT CMakeFiles/cmTC_9a985.dir/src.cxx.obj -MF 
CMakeFiles/cmTC_9a985.dir/src.cxx.obj.d -o CMakeFiles/cmTC_9a985.dir/src.cxx.obj 
-c .../_build/CMakeFiles/CMakeScratch/TryCompile-dqog5x/src.cxx
.../_build/CMakeFiles/CMakeScratch/TryCompile-dqog5x/src.cxx:6:26: warning: format
specifies type 'char *' but the argument has type 
'const std::filesystem::path::value_type *' (aka 'const wchar_t *') [-Wformat]
            printf("%s", cwd.c_str());
                    ~~   ^~~~~~~~~~~
                    %ls
1 warning generated.
```