### PR TITLE
Use bundled icons when theme icons are too small

### DIFF
--- a/src/gui/gsc_main_window_iconview.cpp
+++ b/src/gui/gsc_main_window_iconview.cpp
@@ -554,10 +554,18 @@ Glib::RefPtr<Gdk::Pixbuf> GscMainWindowIconView::load_icon_pixbuf(Glib::RefPtr<G
 {
 	Glib::RefPtr<Gdk::Pixbuf> icon;
 
-	// Try XDG version first
+	// Try the icon theme first; fall back to the bundled icon if needed.
 	try {
 		if (default_icon_theme && !xdg_icon_name.empty()) {
 			icon = default_icon_theme->load_icon(xdg_icon_name, icon_size_, get_scale_factor(), Gtk::IconLookupFlags(0));
+
+			// Some icon themes may return an icon smaller than requested.
+			// In that case, fall back to the bundled icon.
+			if (icon &&
+			    (icon->get_width() < icon_size_ ||
+			     icon->get_height() < icon_size_)) {
+			  icon.reset();
+			}
 		}
 	} catch (...) { }  // ignore exceptions
 


### PR DESCRIPTION
## Problem

On macOS 15.7 under XQuartz, `Gtk::IconTheme::load_icon()` can return a
16×16 icon for `drive-harddisk` even when a 64×64 icon is requested.

Because the theme lookup succeeds, GSmartControl does not fall back to its
bundled icons, resulting in very small drive icons in the main window.

## Solution

This patch keeps the icon theme lookup, but verifies that the returned icon
is at least the requested size. If the theme returns a smaller icon, the
bundled GSmartControl icon is used instead.

## Testing

Verified on macOS 15.7:

- Bundled drive icons are 64×64 PNG files.
- The GTK icon theme lookup returned 16×16 icons despite requesting 64×64.
- After this change, the loaded pixbufs are 64×64.
- The drive icons display correctly in the main window.

The change is not limited to macOS; it also handles icon themes that return
smaller-than-requested icons on other platforms.